### PR TITLE
Fix fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,7 +31,7 @@
     "java": ">=17"
   },
   "suggests": {
-    "cakemod": "Cake Mod by Link4real"
+    "cakemod": "*"
   },
   "custom": {
     "modmenu": {


### PR DESCRIPTION
Fixes the mod failing to load on Quilt Mod Loader (1.19.1 and newer).

Currently using the 1.19.2 version of the mod but this bug should affect the latest version. May I also have permission to privately distribute the 1.19.2 fix between my friends for my private modpack? Thanks