### PR TITLE
Support for 1.21 on Fabric

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "architectury-plugin" version "3.4-SNAPSHOT"
-    id "dev.architectury.loom" version "1.1-SNAPSHOT" apply false
+    id "dev.architectury.loom" version "1.6-SNAPSHOT" apply false
 }
 
 architectury {
@@ -42,7 +42,7 @@ allprojects {
 
     tasks.withType(JavaCompile) {
         options.encoding = "UTF-8"
-        options.release = 17
+        options.release = 22
     }
 
     java {

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.github.johnrengelman.shadow" version "7.1.2"
+    id "com.github.johnrengelman.shadow" version "8.1.1"
 }
 
 architectury {
@@ -41,18 +41,17 @@ shadowJar {
     exclude "architectury.common.json"
 
     configurations = [project.configurations.shadowCommon]
-    classifier "dev-shadow"
+    archiveClassifier = "dev-shadow"
 }
 
 remapJar {
     injectAccessWidener = true
     input.set shadowJar.archiveFile
     dependsOn shadowJar
-    classifier null
 }
 
 jar {
-    classifier "dev"
+    archiveClassifier = "dev"
 }
 
 sourcesJar {

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -24,7 +24,7 @@
   "depends": {
     "fabric": "*",
     "fabricloader": ">=0.14.12",
-    "minecraft": "1.20.x",
+    "minecraft": "1.21.x",
     "architectury": ">=8.1.79"
   },
   "custom": {

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.github.johnrengelman.shadow" version "7.1.2"
+    id "com.github.johnrengelman.shadow" version "8.1.1"
 }
 
 architectury {
@@ -46,17 +46,16 @@ shadowJar {
     exclude "architectury.common.json"
 
     configurations = [project.configurations.shadowCommon]
-    classifier "dev-shadow"
+    archiveClassifier = "dev-shadow"
 }
 
 remapJar {
     input.set shadowJar.archiveFile
     dependsOn shadowJar
-    classifier null
 }
 
 jar {
-    classifier "dev"
+    archiveClassifier = "dev"
 }
 
 sourcesJar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,15 +1,13 @@
 org.gradle.jvmargs=-Xmx2048M
 
-minecraft_version=1.20.4
-enabled_platforms=fabric,forge
+minecraft_version=1.21
+enabled_platforms=fabric
 
 archives_base_name=plushies
-mod_version=1.4.0
+mod_version=1.4.0+1.21.pre.1
 maven_group=com.link
 
-architectury_version=11.0.8
+architectury_version=12.0.27
 
-fabric_loader_version=0.15.3
-fabric_api_version=0.91.3+1.20.4
-
-forge_version=1.20.4-49.0.10
+fabric_loader_version=0.15.11
+fabric_api_version=0.100.0+1.21

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,6 +9,5 @@ pluginManagement {
 
 include("common")
 include("fabric")
-include("forge")
 
 rootProject.name = "architectury-plushies-mod"


### PR DESCRIPTION
👋🏼 I'm not sure if this is useful or not. In fact, at a minimum, it's not mergeable as-is. _But_ it may help others or yourself (@Link4real) add support for 1.21 eventually. 

My wife really wanted plushies in our MC server, and I really wanted to be on 1.21…so here we are! This PR only creates a Fabric-compatible version of the mod, because Maven doesn't have a `12.x` release of [Architectury-Forge](https://mvnrepository.com/artifact/dev.architectury/architectury-forge) for some reason. Not sure if the package is available elsewhere!

I have confirmed the mod indeed runs successfully on a 1.21 Fabric server.

### To build

_Prerequisite: Java 22 is installed_

```bash
$ chmod +x gradlew
$ ./gradlew build
```

That will output the mod at `./fabric/build/libs/plushies-1.4.0+1.21.pre.1.jar`, which can then be copied to a Fabric server + client.

---

Thanks for building such a cool little mod 🙇🏼❤️ 